### PR TITLE
tests: allow TEST_SCENARIO=system

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -80,6 +80,12 @@ You can also run the test against a different Cockpit image, for example:
 
     TEST_OS=fedora-36 make check
 
+In addition to `TEST_OS`, `Makefile` supports also `TEST_SCENARIO` to specify
+which branch of subscription-manager.git to test. If not specified, it defaults
+to `main`. The special value `system` means that subscription-manager is tested
+as available in the test image, without trying to manually build it from its
+repository.
+
 Please see [Cockpit's test documentation](https://github.com/cockpit-project/cockpit/blob/main/test/README.md)
 for details how to run against existing VMs, interactive browser window,
 interacting with the test VM, and more.

--- a/Makefile
+++ b/Makefile
@@ -167,11 +167,12 @@ $(SMBEXT_TAR): subscription-manager
 
 # build a VM with locally built distro pkgs installed
 # disable networking, VM images have mock/pbuilder with the common build dependencies pre-installed
-$(VM_IMAGE): $(NODE_CACHE) $(TARFILE) $(SUBMAN_TAR) $(SMBEXT_TAR) bots test/vm.install
+$(VM_IMAGE): $(NODE_CACHE) $(TARFILE) $(SUBMAN_TAR) $(SMBEXT_TAR) bots test/vm.install test/vm.install-sub-man
 	bots/image-customize --verbose --fresh \
 		--upload $(NODE_CACHE):/var/tmp/ --build $(TARFILE) \
 		--upload $(SUBMAN_TAR):/var/tmp/ \
 		--upload $(SMBEXT_TAR):/var/tmp/ \
+		--script $(CURDIR)/test/vm.install-sub-man \
 		--script $(CURDIR)/test/vm.install $(TEST_OS)
 
 # convenience target for the above

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,14 @@ LIB_TEST=src/lib/cockpit-po-plugin.js
 # common arguments for tar, mostly to make the generated tarballs reproducible
 TAR_ARGS = --sort=name --mtime "@$(shell git show --no-patch --format='%at')" --mode=go=rX,u+rw,a-s --numeric-owner --owner=0 --group=0
 
+ifeq ($(TEST_SCENARIO),system)
+IMAGE_CUSTOMIZE_DEPENDS =
+IMAGE_CUSTOMIZE_INSTALL =
+else
+IMAGE_CUSTOMIZE_DEPENDS = $(SUBMAN_TAR) $(SMBEXT_TAR) test/vm.install-sub-man
+IMAGE_CUSTOMIZE_INSTALL = --upload $(SUBMAN_TAR):/var/tmp/ --upload $(SMBEXT_TAR):/var/tmp/ --script $(CURDIR)/test/vm.install-sub-man
+endif
+
 all: $(WEBPACK_TEST)
 
 #
@@ -167,12 +175,10 @@ $(SMBEXT_TAR): subscription-manager
 
 # build a VM with locally built distro pkgs installed
 # disable networking, VM images have mock/pbuilder with the common build dependencies pre-installed
-$(VM_IMAGE): $(NODE_CACHE) $(TARFILE) $(SUBMAN_TAR) $(SMBEXT_TAR) bots test/vm.install test/vm.install-sub-man
+$(VM_IMAGE): $(NODE_CACHE) $(TARFILE) bots test/vm.install $(IMAGE_CUSTOMIZE_DEPENDS)
 	bots/image-customize --verbose --fresh \
 		--upload $(NODE_CACHE):/var/tmp/ --build $(TARFILE) \
-		--upload $(SUBMAN_TAR):/var/tmp/ \
-		--upload $(SMBEXT_TAR):/var/tmp/ \
-		--script $(CURDIR)/test/vm.install-sub-man \
+		$(IMAGE_CUSTOMIZE_INSTALL) \
 		--script $(CURDIR)/test/vm.install $(TEST_OS)
 
 # convenience target for the above

--- a/test/vm.install
+++ b/test/vm.install
@@ -1,22 +1,6 @@
 #!/bin/sh
 set -eux
 
-dnf install -y cockpit-ws python3-devel openssl-devel intltool gcc
-
-cd /var/tmp
-
-tar -xzf subscription-manager.tar.gz --transform 's,[^/]*,/sm,'
-cd sm
-tar xzf ../subscription-manager-build-extra.tar.gz
-mv subscription-manager/build_ext .
-python3 ./setup.py build
-# Set $RPM_BUILD_ROOT to simulate a package build, so it works fine with the
-# new Python changes in Fedora 36: https://bugzilla.redhat.com/2026979
-RPM_BUILD_ROOT="/" python3 ./setup.py install --prefix /usr --root /
-
-mv /usr/bin/{rhsm-facts-service,rhsm-service,rhsmcertd-worker} /usr/libexec
-mv /usr/bin/subscription-manager /usr/sbin
-
 # don't force https:// (self-signed cert)
 printf "[WebService]\\nAllowUnencrypted=true\\n" > /etc/cockpit/cockpit.conf
 

--- a/test/vm.install-sub-man
+++ b/test/vm.install-sub-man
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eux
+
+dnf install -y cockpit-ws python3-devel openssl-devel intltool gcc
+
+cd /var/tmp
+
+tar -xzf subscription-manager.tar.gz --transform 's,[^/]*,/sm,'
+cd sm
+tar xzf ../subscription-manager-build-extra.tar.gz
+mv subscription-manager/build_ext .
+python3 ./setup.py build
+# Set $RPM_BUILD_ROOT to simulate a package build, so it works fine with the
+# new Python changes in Fedora 36: https://bugzilla.redhat.com/2026979
+RPM_BUILD_ROOT="/" python3 ./setup.py install --prefix /usr --root /
+
+mv /usr/bin/{rhsm-facts-service,rhsm-service,rhsmcertd-worker} /usr/libexec
+mv /usr/bin/subscription-manager /usr/sbin


### PR DESCRIPTION
The test suite already uses `TEST_SCENARIO` to specify which branch of
subscription-manager checkout & test, defaulting to "main". While this
works nicely, it unconditionally tests subscription-manager from
upstream sources.

Introduce a new special value for `TEST_SCENARIO`, i.e. "system": this
does not represent any special branch, but simply avoids installing
subscription-manager from sources, and relies on it being already
installed in the test image. Document the existing behaviour of
`TEST_SCENARIO`, and this new addition, in our `HACKING` file.

The actual implementation is simple: all is needed for a "system"
scenario is to not pass to image-customize the tarballs & scripts of
subscription-manager.