### PR TITLE
Some minor changes

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -41,7 +41,7 @@ remove manually the symlink:
 
 # Running eslint
 
-Cockpit Starter Kit uses [ESLint](https://eslint.org/) to automatically check
+subscription-manager-cockpit uses [ESLint](https://eslint.org/) to automatically check
 JavaScript code style in `.js` and `.jsx` files.
 
 The linter is executed within every build as a webpack preloader.

--- a/HACKING.md
+++ b/HACKING.md
@@ -59,7 +59,7 @@ Rules configuration can be found in the `.eslintrc.json` file.
 # Running tests locally
 
 Run `make check` to build an RPM, install it into a standard Cockpit test VM
-(rhel-8-4 by default), and run the test/check-application integration test on
+(centos-9-stream by default), and run the test/check-application integration test on
 it. This uses Cockpit's Chrome DevTools Protocol based browser tests, through a
 Python API abstraction. Note that this API is not guaranteed to be stable, so
 if you run into failures and don't want to adjust tests, consider checking out
@@ -70,11 +70,11 @@ After the test VM is prepared, you can manually run the test without rebuilding
 the VM, possibly with extra options for tracing and halting on test failures
 (for interactive debugging):
 
-    TEST_OS=rhel-8-4 test/check-subscriptions -tvs
+    TEST_OS=centos-9-stream test/check-subscriptions -tvs
 
 It is possible to setup the test environment without running the tests:
 
-    TEST_OS=rhel-8-4 make prepare-check
+    TEST_OS=centos-9-stream make prepare-check
 
 You can also run the test against a different Cockpit image, for example:
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PACKAGE_NAME := $(shell awk '/"name":/ {gsub(/[",]/, "", $$2); print $$2}' packa
 RPM_NAME := $(PACKAGE_NAME)-cockpit
 VERSION := $(shell T=$$(git describe 2>/dev/null | awk -f get_git_version.awk) || T=1; echo $$T)
 ifeq ($(TEST_OS),)
-TEST_OS = rhel-8-4
+TEST_OS = centos-9-stream
 endif
 export TEST_OS
 # the test scenario is the subscription-manager branch to test against

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ $(SMBEXT_TAR): subscription-manager
 # build a VM with locally built distro pkgs installed
 # disable networking, VM images have mock/pbuilder with the common build dependencies pre-installed
 $(VM_IMAGE): $(NODE_CACHE) $(TARFILE) bots test/vm.install $(IMAGE_CUSTOMIZE_DEPENDS)
-	bots/image-customize --verbose --fresh \
+	bots/image-customize --verbose --fresh --memory-mb 2048 \
 		--upload $(NODE_CACHE):/var/tmp/ --build $(TARFILE) \
 		$(IMAGE_CUSTOMIZE_INSTALL) \
 		--script $(CURDIR)/test/vm.install $(TEST_OS)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "a plugin for cockpit to manage subscriptions",
   "main": "index.js",
-  "repository": "git@github.com:candlepin/subscription-manager.git",
+  "repository": "git@github.com:candlepin/subscription-manager-cockpit.git",
   "author": "",
   "license": "LGPL-2.1",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "scripts": {
     "build": "webpack",
     "po2json": "po2json",
-    "vagrant-watch": "webpack --watch & vagrant rsync-auto",
     "watch": "webpack --watch",
     "clean": "cd ./dist && rm -rf *",
     "eslint": "eslint --ext .jsx --ext .js src/ lib/",

--- a/subscription-manager-cockpit.spec.tmpl
+++ b/subscription-manager-cockpit.spec.tmpl
@@ -3,7 +3,7 @@ Version: %{VERSION}
 Release: 1%{?dist}
 Summary: Subscription Manager Cockpit UI
 Group: System Environment/Base
-License: GPLv2
+License: LGPLv2
 URL: https://www.candlepinproject.org/
 
 Source0: %{name}-%{version}.tar.xz


### PR DESCRIPTION
A number of some very small changes, too small to be sent in their own PRs:
- spec: fix license to LGPLv2
- HACKING: fix project reference
- tests: switch default TEST_OS to centos-9-stream
- Remove one more vagrant leftover
- Fix reference to the repository
- tests: bump image-customize RAM to 2048
