### PR TITLE
webpack: Always regenerate and clean up dist/

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -137,6 +137,9 @@ module.exports = {
     externals: externals,
 
     devtool: production ? false : "source-map",
+    // always regenerate dist/, so make rules work
+    output: { clean: true, compareBeforeEmit: false },
+
     module: {
         rules: [
             {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,12 +42,6 @@ var info = {
     ],
 };
 
-var output = {
-    path: distdir,
-    filename: "[name].js",
-    sourceMapFilename: "[file].map",
-};
-
 /*
  * Note that we're avoiding the use of path.join as webpack and nodejs
  * want relative paths that start with ./ explicitly.
@@ -123,9 +117,6 @@ var plugins = [
 
 /* Only minimize when in production mode */
 if (production) {
-    /* Rename output files when minimizing */
-    output.filename = "[name].min.js";
-
     plugins.unshift(new CompressionPlugin({
         test: /\.(js|html)$/,
         minRatio: 0.9,
@@ -145,7 +136,6 @@ module.exports = {
     },
     externals: externals,
 
-    output: output,
     devtool: production ? false : "source-map",
     module: {
         rules: [


### PR DESCRIPTION
By default, webpack does not clean up dist/, so when you e.g. touch the
code and rebuild with `NODE_ENV=devel`, the old compressed assets from
a previous `production` build were left in place, and cockpit could
serve the old wrong ones. Enable the `clean` output option to fix this [1].

Also force the rewrite of all files with `compareBeforeEmit: false`, so
that the time stamps actually get updated on a webpack run. This fixes
`make` rules and unnecessary rebuilds when nothing changed.

Fixes starter-kit#563

[1] https://webpack.js.org/configuration/output/#outputclean

Cherry-picked from starter-kit commit 3aff8acad1b198cb