### PR TITLE
`Makefile`: avoid spurious echo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,11 +183,11 @@ $(VM_IMAGE): $(NODE_CACHE) $(TARFILE) bots test/vm.install $(IMAGE_CUSTOMIZE_DEP
 
 # convenience target for the above
 vm: $(VM_IMAGE)
-	echo $(VM_IMAGE)
+	@echo $(VM_IMAGE)
 
 # convenience target to print the filename of the test image
 print-vm:
-	echo $(VM_IMAGE)
+	@echo $(VM_IMAGE)
 
 # convenience target to setup all the bits needed for the integration tests
 # without actually running them


### PR DESCRIPTION
Disable the printing of the echo commands that write the filename of the
VM image for tests in the `vm` and `print-vm` targets.

This makes it possible to use their outputs, especially the 'print-vm'
target.

Backport from https://github.com/cockpit-project/starter-kit:
- PR: https://github.com/cockpit-project/starter-kit/pull/568
  - commit https://github.com/cockpit-project/starter-kit/commit/0ece83483d4a33ba58d93f9641711a18c5543f8b