### PR TITLE
spec: limit Group to SUSE distros

### DIFF
--- a/subscription-manager-cockpit.spec.tmpl
+++ b/subscription-manager-cockpit.spec.tmpl
@@ -2,7 +2,9 @@ Name: subscription-manager-cockpit
 Version: %{VERSION}
 Release: 1%{?dist}
 Summary: Subscription Manager Cockpit UI
+%if 0%{?suse_version}
 Group: System Environment/Base
+%endif
 License: LGPLv2
 URL: https://www.candlepinproject.org/
 


### PR DESCRIPTION
Group is no more needed on Red Hat distros for some years already:
https://fedoraproject.org/wiki/Changes/Remove_Group_Tag