### PR TITLE
Fedora packaging fixes

### DIFF
--- a/subscription-manager-cockpit.spec.tmpl
+++ b/subscription-manager-cockpit.spec.tmpl
@@ -53,10 +53,10 @@ of Red Hat subscriptions: subscription-manager-gui, subscription-manager-cockpit
 %prep
 %setup -q -n %{name}
 %setup -q -a 1 -n %{name}
-
-%build
 # ignore pre-built webpack in release tarball and rebuild it
 rm -rf dist
+
+%build
 ESLINT=0 NODE_ENV=production make
 
 %install

--- a/subscription-manager-cockpit.spec.tmpl
+++ b/subscription-manager-cockpit.spec.tmpl
@@ -67,6 +67,9 @@ desktop-file-validate %{buildroot}/%{_datadir}/applications/*
 # drop source maps, they are large and just for debugging
 find %{buildroot}%{_datadir}/cockpit/ -name '*.map' | xargs --no-run-if-empty rm --verbose
 
+%check
+# this can't be meaningfully tested during package build
+
 %files
 %license LICENSE
 %dir %{_datadir}/cockpit/subscription-manager

--- a/subscription-manager-cockpit.spec.tmpl
+++ b/subscription-manager-cockpit.spec.tmpl
@@ -51,8 +51,7 @@ This package contains the desktop icons for the graphical interfaces provided fo
 of Red Hat subscriptions: subscription-manager-gui, subscription-manager-cockpit-plugin.
 
 %prep
-%setup -q -n %{name}
-%setup -q -a 1 -n %{name}
+%autosetup -n %{name} -a 1
 # ignore pre-built webpack in release tarball and rebuild it
 rm -rf dist
 

--- a/subscription-manager-cockpit.spec.tmpl
+++ b/subscription-manager-cockpit.spec.tmpl
@@ -11,6 +11,7 @@ URL: https://www.candlepinproject.org/
 Source0: %{name}-%{version}.tar.xz
 Source1: %{name}-node-%{version}.tar.xz
 BuildArch: noarch
+ExclusiveArch: %{nodejs_arches} noarch
 %if 0%{?fedora}
 BuildRequires: nodejs-devel
 %endif

--- a/subscription-manager-cockpit.spec.tmpl
+++ b/subscription-manager-cockpit.spec.tmpl
@@ -60,13 +60,13 @@ ESLINT=0 NODE_ENV=production make
 
 %install
 %make_install
-desktop-file-validate %{buildroot}/%{_datadir}/applications/*
 
 # drop source maps, they are large and just for debugging
 find %{buildroot}%{_datadir}/cockpit/ -name '*.map' | xargs --no-run-if-empty rm --verbose
 
 %check
 appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
+desktop-file-validate %{buildroot}/%{_datadir}/applications/*
 
 # this can't be meaningfully tested during package build
 

--- a/subscription-manager-cockpit.spec.tmpl
+++ b/subscription-manager-cockpit.spec.tmpl
@@ -11,6 +11,9 @@ URL: https://www.candlepinproject.org/
 Source0: %{name}-%{version}.tar.xz
 Source1: %{name}-node-%{version}.tar.xz
 BuildArch: noarch
+%if 0%{?fedora}
+BuildRequires: nodejs-devel
+%endif
 BuildRequires: nodejs
 BuildRequires: make
 BuildRequires: libappstream-glib

--- a/subscription-manager-cockpit.spec.tmpl
+++ b/subscription-manager-cockpit.spec.tmpl
@@ -60,13 +60,14 @@ ESLINT=0 NODE_ENV=production make
 
 %install
 %make_install
-appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
 desktop-file-validate %{buildroot}/%{_datadir}/applications/*
 
 # drop source maps, they are large and just for debugging
 find %{buildroot}%{_datadir}/cockpit/ -name '*.map' | xargs --no-run-if-empty rm --verbose
 
 %check
+appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
+
 # this can't be meaningfully tested during package build
 
 %files


### PR DESCRIPTION
Backport from https://github.com/cockpit-project/starter-kit some commits that make the packaging more in line with the Fedora guidelines; in addition, add more changes resulting from the Fedora review:
https://bugzilla.redhat.com/show_bug.cgi?id=2081432

- https://github.com/cockpit-project/starter-kit/pull/573
  - https://github.com/cockpit-project/starter-kit/commit/b47bb4714ac8a77459a4656012fae2308b857670
  - https://github.com/cockpit-project/starter-kit/commit/0c954dbf499d93511d0988601bc00f442ab198b2
  - https://github.com/cockpit-project/starter-kit/commit/bee838088d09bc6d73b87e19b26df188266bfc6d
  - https://github.com/cockpit-project/starter-kit/commit/f86c02c60ebb3e87d5ecf62ed0456b20a6d983f4
    - removing the references to fmf, since it is not used here
- https://github.com/cockpit-project/starter-kit/pull/575
  - https://github.com/cockpit-project/starter-kit/commit/e3f668b58453af52602188338d2f729cb77d9f8e
  - https://github.com/cockpit-project/starter-kit/commit/a6508f5d9935cc51a61e2d554d0ccf1c12f34881
- spec: move desktop files validation to %check