### PR TITLE
2093840: spec: drop cockpit-ws

### DIFF
--- a/subscription-manager-cockpit.spec.tmpl
+++ b/subscription-manager-cockpit.spec.tmpl
@@ -28,8 +28,6 @@ Requires: subscription-manager
 Requires: cockpit-bridge
 Requires: cockpit-shell
 Requires: rhsm-icons
-# Used by desktop UI, but not necessary for web UI
-Recommends: cockpit-ws
 
 %description
 Subscription Manager Cockpit UI


### PR DESCRIPTION
The Cockpit Web Service (cockpit-ws) is not required to use the
subscription-manager plugin, and it is something the user chooses to
install directly or indirectly, affecting the entirety of Cockpit.
Hence, drop its Recommends.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2093840
Card ID: ENT-5084