### PR TITLE
spec: suggest insights-client on RHEL

### DIFF
--- a/subscription-manager-cockpit.spec.tmpl
+++ b/subscription-manager-cockpit.spec.tmpl
@@ -28,6 +28,9 @@ Requires: subscription-manager
 Requires: cockpit-bridge
 Requires: cockpit-shell
 Requires: rhsm-icons
+%if %{defined rhel} && %{undefined centos}
+Suggests: insights-client
+%endif
 
 %description
 Subscription Manager Cockpit UI


### PR DESCRIPTION
The Cockpit plugin can register the system to Red Hat Insights using
`insights-client` (which can be installed if missing); hence it makes
sense to add some package relationship for it.

Considering that `insights-client` exists only on RHEL, limit the
insights-client relationship to RHEL only.

Also, `insights-client` is in the AppStream repository, while the Cockpit
plugin is in BaseOS; because of that, there cannot be neither an hard
`Requires` nor a `Recommends`, hence the only way is a `Suggests`.