### PR TITLE
Bump cockpit test API to 273 + run-tests scheduler fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,9 +208,10 @@ bots:
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest release, and update it from time to time
+# 273 + https://github.com/cockpit-project/cockpit/commit/49a7122df2
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 267; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 49a7122df205ab434bab884eb3a7be94d1a8e255; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 


### PR DESCRIPTION
In particular this improves the run-tests scheduler to work better on
our current infrastructure:
https://github.com/cockpit-project/cockpit/commit/49a7122df2

---

sub-man tests currently fail a *lot* [like this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-3640-20220725-091346-535ac172-rhel-8-6-candlepin-subscription-manager-subscription-manager-1.28/log.html). This also needs to be applied to the umpteen older branches, I'll send that once this lands.