### PR TITLE
New target and added one project directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ package-lock.json
 !/po/subscription-manager.pot
 /test/common/
 /test/images/
+.idea

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,9 @@ clean:
 	rm -f $(SPEC)
 	rm -f po/LINGUAS
 
+clean-all:
+	git clean -fdx
+
 install: $(WEBPACK_TEST) po/LINGUAS
 	mkdir -p $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)
 	cp -r dist/* $(DESTDIR)/usr/share/cockpit/$(PACKAGE_NAME)


### PR DESCRIPTION
* When you want to create new release SRPM, then using
  `make clean` before creating SRPM is not enough,
  because node_modules are kept intact. New target
  clean-all deletes all generated files
* Added .idea project directory to .gitignore