### PR TITLE
Fix the issue, when it is not possible to install insights-client

### DIFF
--- a/src/insights.jsx
+++ b/src/insights.jsx
@@ -60,18 +60,31 @@ function spawn_error_to_string(err, data) {
     }
     // the process ran correctly, and exited with a non-zero code: get its
     // combined stdout + stderr
-    return data;
+    if (data) {
+        return data;
+    }
+    // When err contains only string then return this string
+    if (err) {
+        return err;
+    }
+
+    console.debug(">>>> returning undefined");
 }
 
 export function catch_error(err, data) {
     let msg = spawn_error_to_string(err, data);
-    // usually the output of insights-client contains more than a single
-    // line; hence, put each line in its own paragraph, so the error message
-    // is displayed in the same format of what insights-client outputs
-    if (msg.indexOf("\n") > 0)
-        msg = msg.split("\n").map(line => {
-            return <p>{line}</p>;
-        });
+    if (msg) {
+        // usually the output of insights-client contains more than a single
+        // line; hence, put each line in its own paragraph, so the error message
+        // is displayed in the same format of what insights-client outputs
+        if (msg.indexOf("\n") > 0) {
+            msg = msg.split("\n").map(line => {
+                return <p>{line}</p>;
+            });
+        }
+    } else {
+        msg = "Unable to get any error message."
+    }
     subscriptionsClient.setError("error", msg);
 }
 


### PR DESCRIPTION
* When you use Linux distribution, which does not provide
  insights-client in any repository (Fedora, CentOS, ...),
  then sub-man cockpit plugin tried to install anyway,
  when user did not deselect checkbox in registration
  dialog. In this case it wasn't possible to install this
  RPM package, but no error message was displayed and
  registration dialog has been displayed until the whole
  page was reloaded.
* This bug could fix similar issues on RHEL.