### PR TITLE
2077759: invoke cockpit.translate() after document loading

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,6 +146,7 @@ function initStore(rootElement) {
 }
 
 document.addEventListener("DOMContentLoaded", function() {
+    cockpit.translate();
     initStore(document.getElementById('app'));
     dataStore.render();
 });


### PR DESCRIPTION
This way cockpit translates the static elements of the base HTML page of the module, including the page title. This follows what is generally done by other cockpit modules.

Thanks to Martin Pitt for the hint!