### PR TITLE
Support cockpit dark theme

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 
 import 'patternfly/patternfly-4-cockpit.scss';
+import 'cockpit-dark-theme'; // once per page
 
 import subscriptionsClient from './subscriptions-client';
 import SubscriptionRegisterDialog from './subscriptions-register.jsx';


### PR DESCRIPTION
Subscription page is kind of a white bomb when using dark theme elsewhere, this seems to be supported at least since [282.1](https://github.com/cockpit-project/cockpit/commit/c9827febbf31d058f0afdcc522a5af8a87a659c1).

With dark theme applied, it looks like:

![image](https://user-images.githubusercontent.com/1463740/236968162-4fcb68cc-5e1c-4973-8cef-6d7c2fbff79f.png)
