### PR TITLE
Update shared cockpit files for Chromium 113 fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,6 @@ rpm: dist-gzip
 
 # checkout Cockpit's PF/React/build library; again this has no API stability guarantee, so check out a stable tag
 $(LIB_TEST):
-	git clone -b 253 --depth=1 https://github.com/cockpit-project/cockpit.git tmp/cockpit
+	git clone -b 253+chromium-sizzle --depth=1 https://github.com/cockpit-project/cockpit.git tmp/cockpit
 	mv tmp/cockpit/pkg/lib src/
 	rm -rf tmp/cockpit


### PR DESCRIPTION
The most recent Chromium 113 does not work any more with sizzle, tests were hanging as soon as they switched to a frame. The latest cockpit testlib applied a workaround [1]. As the latest Cockpit library also moved to PatternFly 5, but that would be prohibitively expensive for sub-man's stable branch, switch to the (temporary) "253+chromium-sizzle" branch, which has that workaround backported.

[1] https://github.com/cockpit-project/cockpit/pull/18812

---

This will fix the [current test failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-4847-20230606-073138-c9c1f2f3-rhel-8-4-candlepin-subscription-manager-subscription-manager-1.28/log.html), which started to happen with the update to Chromium 113.