### PR TITLE
Fix obsolete cockpit defer API

### DIFF
--- a/src/subscriptions-view.jsx
+++ b/src/subscriptions-view.jsx
@@ -49,24 +49,17 @@ class InstalledProducts extends React.Component {
         if (!event || event.button !== 0)
             return;
         if (this.props.autoAttach) {
-            let self = this;
             this.setState({
                 attaching_in_progress: true,
                 attach_button_text: _("Auto-attaching ...")
             });
             this.props.autoAttach()
-                    .done(function () {
-                        self.setState({
+                    .finally(() =>
+                        this.setState({
                             attaching_in_progress: false,
                             attach_button_text: _("Auto-attach")
-                        });
-                    })
-                    .fail(function () {
-                        self.setState({
-                            attaching_in_progress: false,
-                            attach_button_text: _("Auto-attach")
-                        });
-                    });
+                        })
+                    );
         }
     }
 


### PR DESCRIPTION
done/fail/always is the long-obsolete `cockpit.defer()` jQuery promise API, which will be dropped eventually. Replace them with the standard `Promise` API.

This requires a little teak in safeDBusCall() -- while `.fail()` also returns the rejection, `Promise.catch()` handles it and returns nothing.

In `InstalledProducts.handleAutoAttach()`, both handlers in were doing exactly the same thing, so use finally() instead. Also use an arrow instead of a function to avoid the `self = this` dance.