### PR TITLE
test: Use a more robust way to break Insights uploads 

### DIFF
--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -253,7 +253,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(dialog_register_button_sel)
 
         # old error should disappear
-        with b.wait_timeout(360):
+        with b.wait_timeout(60):
             b.wait_not_in_text(
                 "body", "User doc is member of more organizations, but no organization was selected"
             )
@@ -301,12 +301,11 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(dialog_register_button_sel)
 
         # dialog should disappear
-        with b.wait_timeout(360):
+        with b.wait_timeout(60):
             b.wait_not_present(dialog_register_button_sel)
 
         # make sure this product isn't subscribed
-        with b.wait_timeout(360):
-            self.wait_subscription(PRODUCT_SNOWY, False)
+        self.wait_subscription(PRODUCT_SNOWY, False)
 
         # find another one that is subscribed
         self.wait_subscription(PRODUCT_SHARED, True)
@@ -344,7 +343,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(dialog_register_button_sel)
 
         # dialog should disappear
-        with b.wait_timeout(360):
+        with b.wait_timeout(60):
             b.wait_not_present(dialog_register_button_sel)
 
         # this product should not be subscribed ATM, because auto-attach was skipped
@@ -414,6 +413,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.wait_visible("button:contains('Not connected')")
 
     @skipUnlessDistroFamily("rhel", "Insights support is specific to RHEL")
+    @timeout(900)
     def testSubAndInAndFail(self):
         m = self.machine
         b = self.browser
@@ -444,9 +444,17 @@ class TestSubscriptions(SubscriptionsCase):
 
         b.wait_visible("button:contains('Connected to Insights')")
 
-        # Break the next upload and expect the warning triangle to tell us about it
-        m.execute(["mv", "/etc/insights-client/machine-id", "/etc/insights-client/machine-id.lost"])
-        m.execute(["systemctl", "start", "insights-client"])
+        # Break the next upload and expect the warning triangle to
+        # tell us about it.  This will take a long time:
+        # insights-client will collect all data, and then wait twice
+        # 180 seconds to retry the upload.
+        m.execute(["systemctl", "daemon-reload"])
+        m.execute(["touch", "/etc/insights-client/mock-upload-fail"])
+        m.execute(
+            "systemctl start insights-client; "
+            "while systemctl --quiet is-active insights-client; do sleep 1; done",
+            timeout=720,
+        )
 
         b.wait_visible("button .pf-c-button__icon svg[fill='orange']")
 
@@ -455,7 +463,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.click("button.cancel")
 
         # Unbreak it and retry.
-        m.execute(["mv", "/etc/insights-client/machine-id.lost", "/etc/insights-client/machine-id"])
+        m.execute(["rm", "/etc/insights-client/mock-upload-fail"])
         m.execute(
             "systemctl start insights-client; "
             "while systemctl --quiet is-active insights-client; do sleep 1; done",

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -253,9 +253,10 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(dialog_register_button_sel)
 
         # old error should disappear
-        b.wait_not_in_text(
-            "body", "User doc is member of more organizations, but no organization was selected"
-        )
+        with b.wait_timeout(360):
+            b.wait_not_in_text(
+                "body", "User doc is member of more organizations, but no organization was selected"
+            )
 
         # dialog should disappear
         b.wait_not_present(dialog_register_button_sel)
@@ -300,10 +301,12 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(dialog_register_button_sel)
 
         # dialog should disappear
-        b.wait_not_present(dialog_register_button_sel)
+        with b.wait_timeout(360):
+            b.wait_not_present(dialog_register_button_sel)
 
         # make sure this product isn't subscribed
-        self.wait_subscription(PRODUCT_SNOWY, False)
+        with b.wait_timeout(360):
+            self.wait_subscription(PRODUCT_SNOWY, False)
 
         # find another one that is subscribed
         self.wait_subscription(PRODUCT_SHARED, True)
@@ -341,7 +344,8 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(dialog_register_button_sel)
 
         # dialog should disappear
-        b.wait_not_present(dialog_register_button_sel)
+        with b.wait_timeout(360):
+            b.wait_not_present(dialog_register_button_sel)
 
         # this product should not be subscribed ATM, because auto-attach was skipped
         self.wait_subscription(PRODUCT_SHARED, False)
@@ -380,7 +384,8 @@ class TestSubscriptions(SubscriptionsCase):
 
         dialog_register_button_sel = "footer .pf-m-primary"
         b.click(dialog_register_button_sel)
-        b.wait_not_present(dialog_register_button_sel)
+        with b.wait_timeout(360):
+            b.wait_not_present(dialog_register_button_sel)
 
         b.click("button:contains('Not connected')")
         b.wait_visible('.pf-c-modal-box__body:contains("This system is not connected")')
@@ -460,7 +465,8 @@ class TestSubscriptions(SubscriptionsCase):
         b.wait_not_present("button .pf-c-button__icon svg[fill='orange']")
 
         b.click("button:contains('Unregister')")
-        b.wait_not_in_text("#overview", "Insights")
+        with b.wait_timeout(60):
+            b.wait_not_in_text("#overview", "Insights")
         m.execute(["test", "-f", "/etc/insights-client/.unregistered"])
 
 

--- a/test/files/mock-insights
+++ b/test/files/mock-insights
@@ -115,9 +115,13 @@ class handler(BaseHTTPRequestHandler):
 
         m = self.match("/r/insights/uploads/([^/])+")
         if m:
-            self.send_response(200)
-            self.end_headers()
-            self.wfile.write(b'{ "reports": [ "foo", "bar" ] }\n')
+            if os.path.exists("/etc/insights-client/mock-upload-fail"):
+                self.send_response(403)
+                self.end_headers()
+            else:
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b'{ "reports": [ "foo", "bar" ] }\n')
             return
 
         self.send_response(404)


### PR DESCRIPTION
Insights-client seems to have gotten slower recently, so let's wait longer for it to fail the upload.

And also, provoke the upload failure by returning a proper error code from mock-insights.