### PR TITLE
chore: bump version of black to 24.3.0

### DIFF
--- a/.github/workflows/stylish.yml
+++ b/.github/workflows/stylish.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: psf/black@stable
       with:
-        version: "23.3.0"
+        version: "24.3.0"
 
     - name: Setup flake8 annotations
       uses: rbialon/flake8-annotations@v1


### PR DESCRIPTION
No changes were needed.