### PR TITLE
tests: fix Insights test, increase certain timeouts

### DIFF
--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -253,9 +253,10 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(dialog_register_button_sel)
 
         # old error should disappear
-        b.wait_not_in_text(
-            "body", "User doc is member of more organizations, but no organization was selected"
-        )
+        with b.wait_timeout(60):
+            b.wait_not_in_text(
+                "body", "User doc is member of more organizations, but no organization was selected"
+            )
 
         # dialog should disappear
         b.wait_not_present(dialog_register_button_sel)
@@ -300,7 +301,8 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(dialog_register_button_sel)
 
         # dialog should disappear
-        b.wait_not_present(dialog_register_button_sel)
+        with b.wait_timeout(60):
+            b.wait_not_present(dialog_register_button_sel)
 
         # make sure this product isn't subscribed
         self.wait_subscription(PRODUCT_SNOWY, False)
@@ -341,7 +343,8 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(dialog_register_button_sel)
 
         # dialog should disappear
-        b.wait_not_present(dialog_register_button_sel)
+        with b.wait_timeout(60):
+            b.wait_not_present(dialog_register_button_sel)
 
         # this product should not be subscribed ATM, because auto-attach was skipped
         self.wait_subscription(PRODUCT_SHARED, False)
@@ -349,7 +352,8 @@ class TestSubscriptions(SubscriptionsCase):
         b.click("button:contains('Auto-attach')")
 
         # find another one that is subscribed
-        self.wait_subscription(PRODUCT_SHARED, True)
+        with b.wait_timeout(60):
+            self.wait_subscription(PRODUCT_SHARED, True)
 
     def testUnpriv(self):
         self.machine.execute("useradd junior; echo junior:foobar | chpasswd")
@@ -380,7 +384,8 @@ class TestSubscriptions(SubscriptionsCase):
 
         dialog_register_button_sel = "footer .pf-m-primary"
         b.click(dialog_register_button_sel)
-        b.wait_not_present(dialog_register_button_sel)
+        with b.wait_timeout(60):
+            b.wait_not_present(dialog_register_button_sel)
 
         b.click("button:contains('Not connected')")
         b.wait_visible('.pf-c-modal-box__body:contains("This system is not connected")')
@@ -443,7 +448,8 @@ class TestSubscriptions(SubscriptionsCase):
         m.execute(["mv", "/etc/insights-client/machine-id", "/etc/insights-client/machine-id.lost"])
         m.execute(["systemctl", "start", "insights-client"])
 
-        b.wait_visible("button .pf-c-button__icon svg[fill='orange']")
+        with b.wait_timeout(60):
+            b.wait_visible("button .pf-c-button__icon svg[fill='orange']")
 
         b.click("button:contains('Connected to Insights')")
         b.wait_visible('.pf-c-modal-box__body:contains("The last Insights data upload has failed")')
@@ -460,7 +466,8 @@ class TestSubscriptions(SubscriptionsCase):
         b.wait_not_present("button .pf-c-button__icon svg[fill='orange']")
 
         b.click("button:contains('Unregister')")
-        b.wait_not_in_text("#overview", "Insights")
+        with b.wait_timeout(60):
+            b.wait_not_in_text("#overview", "Insights")
         m.execute(["test", "-f", "/etc/insights-client/.unregistered"])
 
 

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -19,6 +19,7 @@
 import os
 import sys
 import unittest
+import uuid
 
 # import Cockpit's machinery for test VMs and its browser test API
 TEST_DIR = os.path.dirname(__file__)
@@ -444,8 +445,10 @@ class TestSubscriptions(SubscriptionsCase):
 
         b.wait_visible("button:contains('Connected to Insights')")
 
-        # Break the next upload and expect the warning triangle to tell us about it
-        m.execute(["mv", "/etc/insights-client/machine-id", "/etc/insights-client/machine-id.lost"])
+        # Break the next upload and expect the warning triangle to tell us about it;
+        # write over the original file so its SELinux attributes are preserved.
+        m.execute(["cp", "/etc/insights-client/machine-id", "/etc/insights-client/machine-id.orig"])
+        m.write("/etc/insights-client/machine-id", str(uuid.uuid4()))
         m.execute(["systemctl", "start", "insights-client"])
 
         with b.wait_timeout(60):
@@ -456,7 +459,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.click("button.cancel")
 
         # Unbreak it and retry.
-        m.execute(["mv", "/etc/insights-client/machine-id.lost", "/etc/insights-client/machine-id"])
+        m.execute(["mv", "/etc/insights-client/machine-id.orig", "/etc/insights-client/machine-id"])
         m.execute(
             "systemctl start insights-client; "
             "while systemctl --quiet is-active insights-client; do sleep 1; done",

--- a/test/files/mock-insights
+++ b/test/files/mock-insights
@@ -51,12 +51,13 @@ class handler(BaseHTTPRequestHandler):
         m = self.match("/r/insights/v1/systems/([^/]+)")
         if m:
             machine_id = m[1]
+            if machine_id not in systems:
+                self.send_response(404)
+                self.end_headers()
+                return
             self.send_response(200)
             self.end_headers()
-            if machine_id in systems:
-                self.wfile.write(json.dumps(systems[machine_id]).encode("utf-8") + b"\n")
-            else:
-                self.wfile.write(b"{ }\n")
+            self.wfile.write(json.dumps(systems[machine_id]).encode("utf-8") + b"\n")
             return
 
         m = self.match("/r/insights/v1/branch_info")


### PR DESCRIPTION
Fix the tests, and in particular `testSubAndInAndFail`, to ensure they work properly in all the cases, and also with newer versions of `insights-core`:
- extend the timeouts for certain registration, unregistration, and Insights operations
- fix `mock-insights` to properly error out when querying for an unregistered system
- use a different method to break `insights-client` according to newer changes in `insights-core`

See the messages of the various commits for much longer descriptions of the reasons & changes.