### PR TITLE
test: wait more when registering to Insights

### DIFF
--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -391,7 +391,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.click("button:contains('Not connected')")
         b.wait_visible('.pf-c-modal-box__body:contains("This system is not connected")')
         b.click("footer button.apply")
-        with b.wait_timeout(360):
+        with b.wait_timeout(600):
             b.wait_not_present(".pf-c-modal-box")
 
         b.wait_visible("#overview a[href='http://cloud.redhat.com/insights/inventory/123-nice-id']")
@@ -443,7 +443,8 @@ class TestSubscriptions(SubscriptionsCase):
         with b.wait_timeout(360):
             b.wait_not_present(dialog_register_button_sel)
 
-        b.wait_visible("button:contains('Connected to Insights')")
+        with b.wait_timeout(600):
+            b.wait_visible("button:contains('Connected to Insights')")
 
         # Break the next upload and expect the warning triangle to tell us about it;
         # write over the original file so its SELinux attributes are preserved.


### PR DESCRIPTION
The data collection done by insights-client takes more and more time, and it may take even more in case the test system (running as VM) is running inside another VM.

Hence, extend a bit more the timeout needed while waiting for the registration to Insights.

Extends/updates commit c006e1ed6f29f56691f2f31f225246d1e8311864.