### PR TITLE
fix: Remove Auto-attach button

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -80,8 +80,7 @@ function openRegisterDialog() {
             insights: true,
             insights_available: subscriptionsClient.insightsAvailable,
             insights_detected: false,
-            register_method: 'account',
-            auto_attach: true
+            register_method: 'account'
         });
 
         Insights.detect().then(installed => {
@@ -135,7 +134,6 @@ function initStore(rootElement) {
                 syspurpose: subscriptionsClient.syspurposeStatus.info,
                 syspurpose_status: subscriptionsClient.syspurposeStatus.status,
                 insights_available: subscriptionsClient.insightsAvailable,
-                autoAttach: subscriptionsClient.autoAttach,
                 org: subscriptionsClient.org,
                 dismissError: dismissStatusError,
                 register: openRegisterDialog,

--- a/src/subscriptions-client.js
+++ b/src/subscriptions-client.js
@@ -30,7 +30,6 @@ function createProxy(name) {
 // creates multiple services otherwise only readies one proxy at a time
 const configService = createProxy('Config');
 const registerServer = createProxy('RegisterServer');
-const attachService = createProxy('Attach');
 const entitlementService = createProxy('Entitlement');
 const unregisterService = createProxy('Unregister');
 const productsService = createProxy('Products');
@@ -355,7 +354,7 @@ client.registerSystem = (subscriptionDetails, update_progress) => new Promise((r
                     else {
                         console.debug('registering using username and password');
                         const registration_options = {
-                            "enable_content": dbus_bool(subscriptionDetails.auto_attach)
+                            "enable_content": dbus_bool(true)
                         };
                         console.log('registration_options:', registration_options);
                         if (update_progress)
@@ -426,7 +425,7 @@ client.registerSystem = (subscriptionDetails, update_progress) => new Promise((r
                     }
                 })
                 .catch(error => {
-                    console.error('error during auto-attach', error);
+                    console.error('error during enabling content', error);
                     isRegistering = false;
                     reject(parseErrorMessage(error));
                 })
@@ -461,19 +460,6 @@ client.unregisterSystem = () => {
                     requestSubscriptionStatusUpdate();
                 });
     });
-};
-
-client.autoAttach = () => {
-    console.debug('auto-attaching ...');
-    return attachService.AutoAttach('', {}, userLang)
-            .then(() => needRender())
-            .catch(error => {
-                console.error('error during auto-attach', error);
-                client.subscriptionStatus.error = {
-                    'severity': parseErrorSeverity(error),
-                    'msg': parseErrorMessage(error)
-                };
-            });
 };
 
 function statusUpdateFailed(reason) {

--- a/src/subscriptions-register.jsx
+++ b/src/subscriptions-register.jsx
@@ -75,19 +75,11 @@ class SubscriptionRegisterDialog extends React.Component {
             );
         }
         let insights;
-        let insights_checkbox_disabled = true;
-        if (this.props.insights_available === true) {
-            insights_checkbox_disabled = false;
-        } else {
-            if (this.props.auto_attach === true) {
-                insights_checkbox_disabled = false;
-            }
-        }
         insights = [
             <FormGroup key="0" fieldId="subscription-insights" label={_("Insights")} hasNoPaddingTop>
                 <Checkbox id="subscription-insights" isChecked={this.props.insights}
                           label={ Insights.arrfmt(_("Connect this system to $0."), Insights.link) }
-                          isDisabled={ insights_checkbox_disabled }
+                          isDisabled={ false }
                           onChange={value => this.props.onChange('insights', value)}
                 />
                 {(this.props.insights && !this.props.insights_detected) &&
@@ -175,15 +167,6 @@ class SubscriptionRegisterDialog extends React.Component {
                                isChecked={this.props.register_method === 'activation-key'} />
                     </Flex>
                     { credentials }
-                </FormGroup>
-                <FormGroup className="control-label" label={_("Subscriptions")} hasNoPaddingTop>
-                    <Checkbox id="subscription-auto-attach-use" isChecked={this.props.auto_attach}
-                              label={_("Attach automatically")}
-                              onChange={value => {
-                                  this.props.onChange('auto_attach', value);
-                                  this.props.insights && !value && this.props.onChange('insights', value);
-                              }}
-                    />
                 </FormGroup>
                 { insights }
             </Form>

--- a/src/subscriptions-view.jsx
+++ b/src/subscriptions-view.jsx
@@ -37,30 +37,6 @@ let _ = cockpit.gettext;
 class InstalledProducts extends React.Component {
     constructor(props) {
         super(props);
-        this.state = {
-            attaching_in_progress: false,
-            attach_button_text: _("Auto-attach")
-        };
-        this.handleAutoAttach = this.handleAutoAttach.bind(this);
-    }
-
-    handleAutoAttach(event) {
-        // only consider primary mouse button
-        if (!event || event.button !== 0)
-            return;
-        if (this.props.autoAttach) {
-            this.setState({
-                attaching_in_progress: true,
-                attach_button_text: _("Auto-attaching ...")
-            });
-            this.props.autoAttach()
-                    .finally(() =>
-                        this.setState({
-                            attaching_in_progress: false,
-                            attach_button_text: _("Auto-attach")
-                        })
-                    );
-        }
     }
 
     render() {
@@ -78,18 +54,6 @@ class InstalledProducts extends React.Component {
         }
 
         let card_actions;
-        if (sca_mode === false) {
-            card_actions = (
-                <CardActions>
-                    <Button
-                            isDisabled={this.state.attaching_in_progress || this.props.status === 'unknown'}
-                            onClick={this.handleAutoAttach}>
-                        { this.state.attach_button_text }
-                    </Button>
-                </CardActions>
-            )
-        }
-
         let entries = this.props.products.map(function (itm) {
             let status_color;
             let status_text;

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -320,42 +320,6 @@ class TestSubscriptions(SubscriptionsCase):
         # find another one that isn't subscribed too
         self.wait_subscription(PRODUCT_SHARED, False)
 
-    def testRegisterWithoutAutoAttach(self):
-        b = self.browser
-
-        self.login_and_go("/subscriptions")
-
-        # wait until we can open the registration dialog
-        register_button_sel = "button:contains('Register')"
-        b.click(register_button_sel)
-
-        b.wait_visible("#subscription-register-url")
-
-        # enter server and correct login data
-        b.set_val("#subscription-register-url", "custom")
-        b.set_input_text("#subscription-register-url-custom", CANDLEPIN_URL)
-        b.set_input_text("#subscription-register-username", "doc")
-        b.set_input_text("#subscription-register-password", "password")
-        b.set_input_text("#subscription-register-org", "snowwhite")
-
-        b.click("#subscription-auto-attach-use")
-
-        dialog_register_button_sel = "footer .pf-m-primary"
-        b.click(dialog_register_button_sel)
-
-        # dialog should disappear
-        with b.wait_timeout(60):
-            b.wait_not_present(dialog_register_button_sel)
-
-        # this product should not be subscribed ATM, because auto-attach was skipped
-        self.wait_subscription(PRODUCT_SHARED, False)
-
-        b.click("button:contains('Auto-attach')")
-
-        # find another one that is subscribed
-        with b.wait_timeout(60):
-            self.wait_subscription(PRODUCT_SHARED, True)
-
     def testUnpriv(self):
         self.machine.execute("useradd junior; echo junior:foobar | chpasswd")
         self.login_and_go("/subscriptions", user="junior")


### PR DESCRIPTION
* Card ID: CCT-425
* Removed "Auto-Attach" button, because corresponding D-Bus method was removed from rhsm.service due to SCA only effort
* Renamed "Auto-attach" option from registration dialog to "Enable content"
* Modified integration tests