### PR TITLE
feat: switch from .last-upload.results to .lastupload

### DIFF
--- a/src/insights.jsx
+++ b/src/insights.jsx
@@ -369,17 +369,15 @@ function jump_to_timer() {
 function monitor_last_upload() {
     let self = {
         timestamp: 0,
-        results: null,
 
         close: close
     };
 
     cockpit.event_target(self);
 
-    let results_file = cockpit.file("/etc/insights-client/.last-upload.results", { syntax: JSON });
-    results_file.watch(data => {
-        self.results = data;
-        cockpit.spawn([ "stat", "-c", "%Y", "/etc/insights-client/.last-upload.results" ], { err: "message" })
+    let results_file = cockpit.file("/etc/insights-client/.lastupload");
+    results_file.watch(() => {
+        cockpit.spawn([ "stat", "-c", "%Y", "/etc/insights-client/.lastupload" ], { err: "message" })
                 .then(ts => {
                     self.timestamp = parseInt(ts);
                     self.dispatchEvent("changed");
@@ -388,7 +386,7 @@ function monitor_last_upload() {
                     self.timestamp = 0;
                     self.dispatchEvent("changed");
                 });
-    });
+    }, { read: false });
 
     function close() {
         results_file.close();


### PR DESCRIPTION
The file `/etc/insights-client/.last-upload.results` is watched to determine when was the last upload done. A couple of important notes about it:
1) even though it is read (and parsed), its content is actually never used currently
2) the file is written by insights-client (better: insights-core) only when `legacy_upload` is true (which is the default as of this writing)

While (1) is not much an issue, (2) means that the displaying of the last upload (timestamp) to Insights is not available when switching insights-client to non-legacy-upload.

To avoid both the issues, switch from `.last-upload.results` to `/etc/insights-client/.lastupload`:
- `.lastupload` is always written, no matter the mode, and its modification timestamp is indeed accurate
- stop reading the file at all, saving a bit of resources

There should be no behaviour changes.