### PR TITLE
chore: ignore node_modules for flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -17,3 +17,5 @@ extend-exclude =
     src/lib/,
     subscription-manager/,
     test/common/,
+    # node modules
+    node_modules/,


### PR DESCRIPTION
Explicitly ignore the locally downloaded nodejs modules when running flake8 (as flake8 does not use `.gitignore`); this way it is possible to run flake8 while developing and running tests.