### PR TITLE
test: switch to CERT auth for insights-client

### DIFF
--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -192,8 +192,7 @@ auto_config=False
 auto_update=False
 base_url={hostname}:8443/r/insights
 cert_verify=/var/lib/insights/mock-certs/ca.crt
-username=admin
-password=foobar
+authmethod=CERT
 """,
             )
 

--- a/test/files/mock-insights
+++ b/test/files/mock-insights
@@ -14,8 +14,7 @@
 # auto_update=False
 # base_url=127.0.0.1:8443/r/insights
 # cert_verify=/var/lib/insights/mock-certs/ca.crt
-# username=admin
-# password=foobar
+# authmethod=CERT
 
 import email
 from http.server import BaseHTTPRequestHandler, HTTPServer


### PR DESCRIPTION
Switch the authentication method of insights-client to CERT-based, which uses the consumer certificate & key of subscription-manager.

This means using mTLS for authentication, still without verifying them, just like the previous fake credentials; this is still acceptable in the testing environment of a transient guest.