### PR TITLE
test: mock-insights: switch away from ssl.wrap_socket()

### DIFF
--- a/test/files/mock-insights
+++ b/test/files/mock-insights
@@ -213,12 +213,10 @@ def insights_server(port):
         subprocess.check_call(["sscg"], cwd=certdir)
 
     httpd = HTTPServer(("", port), handler)
-    ssl_args = {
-        "certfile": f"{certdir}/service.pem",
-        "keyfile": f"{certdir}/service-key.pem",
-        "server_side": True,
-    }
-    httpd.socket = ssl.wrap_socket(httpd.socket, **ssl_args)
+    ctx = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+    ctx.load_default_certs()
+    ctx.load_cert_chain(f"{certdir}/service.pem", f"{certdir}/service-key.pem")
+    httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
     httpd.serve_forever()
 
 


### PR DESCRIPTION
`ssl.wrap_socket()` is long deprecated, and dropped in Python 3.12. Switch to use an `SSLContext` for client authentication. Load also the system CA store, as it contains the Candlepin CA: this way, the CERT-based authentication (using the consumer certificate generated by Candlepin) can be validated.