### PR TITLE
test: setup the subscription repositories

### DIFF
--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -181,6 +181,25 @@ class SubscriptionsCase(MachineCase):
         # Wait for the web service to be accessible
         machine_python(self.machine, WAIT_SCRIPT, CANDLEPIN_URL)
 
+        # Setup the repositories properly using the Candlepin RPM GPG key
+        m.execute(
+            [
+                "curl",
+                "-o",
+                "/etc/pki/rpm-gpg/RPM-GPG-KEY-candlepin",
+                f"http://{CANDLEPIN_HOSTNAME}:8080/RPM-GPG-KEY-candlepin",
+            ]
+        )
+        machine_restorecon(self.machine, "/etc/pki/rpm-gpg/")
+        m.execute(
+            [
+                "subscription-manager",
+                "config",
+                "--rhsm.baseurl",
+                f"http://{CANDLEPIN_HOSTNAME}:8080",
+            ]
+        )
+
         hostname = m.execute(["hostname"]).rstrip()
 
         if m.image.startswith("rhel-"):


### PR DESCRIPTION
Ensure that subscription-manager is configured so that the package manager can properly receive content from the repositories of the self-deployed Candlepin. This should have been done in the past, and it will be critical for switching to SCA for testing: in SCA mode, all the content of the organization is available by default, and some repositories are also automatically enabled.

This means:
- installing the GPG key for RPM packages
- setting the baseurl in rhsm.conf

-------

This PR requires an updated `services` cockpit image after https://github.com/cockpit-project/bots/pull/6708 is merged.