### PR TITLE
fix: switch to the proper URL for Red Hat's Hybrid Cloud Console

### DIFF
--- a/src/insights.jsx
+++ b/src/insights.jsx
@@ -520,9 +520,9 @@ export class InsightsStatus extends React.Component {
 
             let url;
             try {
-                url = "http://cloud.redhat.com/insights/inventory/" + this.state.host_details.results[0].id;
+                url = "https://console.redhat.com/insights/inventory/" + this.state.host_details.results[0].id;
             } catch (err) {
-                url = "http://cloud.redhat.com/insights";
+                url = "https://console.redhat.com/insights";
             }
 
             let text;

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -376,7 +376,7 @@ class TestSubscriptions(SubscriptionsCase):
         with b.wait_timeout(600):
             b.wait_not_present(".pf-c-modal-box")
 
-        b.wait_visible("#overview a[href='http://cloud.redhat.com/insights/inventory/123-nice-id']")
+        b.wait_visible("#overview a[href='https://console.redhat.com/insights/inventory/123-nice-id']")
         b.wait_visible("#overview a:contains('3 hits, including important')")
 
         # test system purpose


### PR DESCRIPTION
The right hostname is console.redhat.com, rather than the deprecated cloud.redhat.com. Also use the secure https for it instead of http.