### PR TITLE
test: switch one more org to SCA one

### DIFF
--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -264,7 +264,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.wait_in_text("body", "User huey is member of more organizations, but no organization was selected")
 
         # now specify the org
-        b.set_input_text("#subscription-register-org", "snowwhite")
+        b.set_input_text("#subscription-register-org", "donaldduck")
 
         # try to register again
         b.click(dialog_register_button_sel)


### PR DESCRIPTION
Use "donaldduck" as organization to really register using SCA.

Followup of commit 16caea1552fcede7a7318a60153c46bfe94fe650.