### PR TITLE
Update cockpit test lib to 323

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -219,10 +219,10 @@ bots:
 
 # checkout Cockpit's test API; this has no API stability guarantee, so check out a stable tag
 # when you start a new project, use the latest release, and update it from time to time
-# 292 + sizzle workaround for Chromium 113
+# 323
 test/common:
 	flock Makefile sh -ec '\
-	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git d9426e07a261c182d61163900740fd74d02fe99b; \
+	    git fetch --depth=1 https://github.com/cockpit-project/cockpit.git 79623a0a425600da302f66a2752afe35c96f6cf3; \
 	    git checkout --force FETCH_HEAD -- test/common; \
 	    git reset test/common'
 

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/python3 -cimport os, sys; os.execv(os.path.dirname(sys.argv[1]) + "/../test/common/pywrap", sys.argv)
 # This file is part of Cockpit.
 #
 # Copyright (C) 2016 Red Hat, Inc.
@@ -17,17 +17,12 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import sys
 import unittest
 import uuid
 
-# import Cockpit's machinery for test VMs and its browser test API
-TEST_DIR = os.path.dirname(__file__)
-sys.path.append(os.path.join(TEST_DIR, "common"))
-sys.path.append(os.path.join(os.path.dirname(TEST_DIR), "bots/machine"))
 from packagelib import *
 from testlib import *
-import testvm
+from machine import testvm
 
 # candlepin on the services image has a lot of demo data preloaded
 # useful info/commands:


### PR DESCRIPTION
This requires a couple of adaptations in the actual test script:
- make use of the `pywrap` script available in cockpit's `test/common` to import all the right modules for us (removing the manual imports)
- tweak the import of `testvm` to be done like done in cockpit tests

There should be no behaviour changes.