### PR TITLE
test: various misc changes

### DIFF
--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -88,7 +88,7 @@ class SubscriptionsCase(MachineCase):
         self.candlepin.execute(["/root/run-candlepin"])
 
         # make sure the cockpit machine can resolve the service machine hostname
-        m.execute(f"echo '{CANDLEPIN_ADDR} {CANDLEPIN_HOSTNAME}' >> /etc/hosts")
+        m.write("/etc/hosts", f"{CANDLEPIN_ADDR} {CANDLEPIN_HOSTNAME}\n", append=True)
 
         # download product info from the candlepin machine
         def download_product(product):

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -60,11 +60,6 @@ PRODUCT_SHARED = {
 # fmt: on
 
 
-def machine_python(machine, script, *args):
-    cmd = ["python3", "-c", script] + list(args)
-    return machine.execute(cmd)
-
-
 def machine_restorecon(machine, path, *args):
     cmd = ["restorecon", "-R", path] + list(args)
     return machine.execute(cmd)

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -17,12 +17,10 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import unittest
 import uuid
 
 from packagelib import *
 from testlib import *
-from machine import testvm
 
 # candlepin on the services image has a lot of demo data preloaded
 # useful info/commands:
@@ -123,15 +121,6 @@ def machine_python(machine, script, *args):
 def machine_restorecon(machine, path, *args):
     cmd = ["restorecon", "-R", path] + list(args)
     return machine.execute(cmd)
-
-
-def skipUnlessDistroFamily(distro, reason):
-    """
-    Skip the current test function with the specified [reason]
-    unless the distribution of the machine is part of the specified
-    family [distro] (i.e. it starts as "distro-").
-    """
-    return unittest.skipUnless(testvm.DEFAULT_IMAGE.startswith(distro + "-"), reason)
 
 
 class SubscriptionsCase(MachineCase):
@@ -324,7 +313,7 @@ class TestSubscriptions(SubscriptionsCase):
         )
         self.allow_journal_messages("junior is not in the sudoers file.  This incident will be reported.")
 
-    @skipUnlessDistroFamily("rhel", "Insights support is specific to RHEL")
+    @onlyImage("Insights support is specific to RHEL", "rhel-*")
     def testInsights(self):
         m = self.machine
         b = self.browser
@@ -376,7 +365,7 @@ class TestSubscriptions(SubscriptionsCase):
 
         b.wait_visible("button:contains('Not connected')")
 
-    @skipUnlessDistroFamily("rhel", "Insights support is specific to RHEL")
+    @onlyImage("Insights support is specific to RHEL", "rhel-*")
     def testSubAndInAndFail(self):
         m = self.machine
         b = self.browser

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -40,16 +40,6 @@ from testlib import *
 #
 # to use the candlepin image on a test machine, either add the certificate or
 # allow insecure connections (/etc/rhsm/rhsm.conf -> "insecure = 1")
-#
-# $IP is the ip of the candlepin machine
-#
-# add an activation key to a pool:
-# curl --insecure --request POST --user huey:password \
-# https://$IP:8443/candlepin/activation_keys/ff80808155ca50b10155ca50cd280010/pools/ff80808155ca50b10155ca51f04607e5
-# register with: activation key "awesome_os_pool" and org "donaldduck"
-#
-# in order to get the right ids for the activation key and pool, see
-# ACTIVATION_KEY_SCRIPT
 
 WAIT_SCRIPT = """
 import sys
@@ -70,29 +60,6 @@ for i in range(1, 200):
         break
     except:
         time.sleep(1)
-"""
-
-ACTIVATION_KEY_SCRIPT = """
-import sys
-import json
-import requests
-
-data = requests.get(sys.argv[1] + "/activation_keys", auth=("huey", "password")).json()
-key = [
-    e["id"] for e in data if e["name"] == "awesome_os_pool" and e["owner"]["displayName"] == "Admin Owner"
-][0]
-
-data = requests.get(sys.argv[1] + "/pools", auth=("huey", "password")).json()
-pool = [
-    e["id"]
-    for e in data
-    if e["owner"]["key"] == "admin"
-    and e["contractNumber"] == "0"
-    and [p for p in e["providedProducts"] if p["productId"] == "88888"]
-][0]
-
-key_url = sys.argv[1] + "/activation_keys/{key}/pools/{pool}".format(key=key, pool=pool)
-requests.post(key_url, auth=("huey", "password"))
 """
 
 # fmt: off
@@ -290,8 +257,6 @@ class TestSubscriptions(SubscriptionsCase):
         activation_key_checkbox = "#subscription-register-activation-key-method"
         b.click(activation_key_checkbox)
 
-        # make sure we have an activation key on the target machine
-        machine_python(self.machine, ACTIVATION_KEY_SCRIPT, CANDLEPIN_URL)
         b.set_input_text("#subscription-register-key", "awesome_os_pool")
         b.set_input_text("#subscription-register-org", "donaldduck")
 

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -148,9 +148,9 @@ class SubscriptionsCase(MachineCase):
             prod_id = product["id"]
             filename = os.path.join(self.tmpdir, "%s.pem" % prod_id)
             self.candlepin.download("/home/admin/candlepin/generated_certs/%s.pem" % prod_id, filename)
-            m.upload([filename], "/etc/pki/product")
+            m.upload([filename], "/etc/pki/product-default")
 
-        m.execute(["mkdir", "-p", "/etc/pki/product"])
+        m.execute(["mkdir", "-p", "/etc/pki/product-default"])
         download_product(PRODUCT_DONALDY)
         download_product(PRODUCT_SHARED)
 

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -17,6 +17,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import time
 import uuid
 
 from packagelib import *
@@ -40,27 +41,6 @@ from testlib import *
 #
 # to use the candlepin image on a test machine, either add the certificate or
 # allow insecure connections (/etc/rhsm/rhsm.conf -> "insecure = 1")
-
-WAIT_SCRIPT = """
-import sys
-import time
-import requests
-
-# minimum waiting time for Candlepin to answer (in seconds)
-waiting_time = 10
-
-sys.stderr.write("Waiting %s seconds for %s\\n" % (waiting_time, sys.argv[1]))
-sys.stderr.flush()
-time.sleep(waiting_time)
-for i in range(1, 200):
-    try:
-        sys.stderr.write("Waiting for %s\\n" % sys.argv[1])
-        sys.stderr.flush()
-        res = requests.get(sys.argv[1])
-        break
-    except:
-        time.sleep(1)
-"""
 
 # fmt: off
 CLIENT_ADDR = "10.111.112.1"
@@ -133,8 +113,10 @@ class SubscriptionsCase(MachineCase):
         m.upload([candlepin_ca_tmpfile], f"/etc/rhsm/ca/{candlepin_ca_filename}")
         machine_restorecon(self.machine, "/etc/rhsm/ca/")
 
-        # Wait for the web service to be accessible
-        machine_python(self.machine, WAIT_SCRIPT, CANDLEPIN_URL)
+        # Wait for the web service to be accessible, with an initial delay
+        # to give more time to Candlepin to start
+        time.sleep(10)
+        m.execute(f"until curl --fail --silent --show-error {CANDLEPIN_URL}/status; do sleep 1; done")
 
         # Setup the repositories properly using the Candlepin RPM GPG key
         m.execute(

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -46,7 +46,7 @@ from testlib import *
 CLIENT_ADDR = "10.111.112.1"
 CANDLEPIN_ADDR = "10.111.112.100"
 CANDLEPIN_HOSTNAME = "services.cockpit.lan"
-CANDLEPIN_URL = "https://%s:8443/candlepin" % CANDLEPIN_HOSTNAME
+CANDLEPIN_URL = f"https://{CANDLEPIN_HOSTNAME}:8443/candlepin"
 
 PRODUCT_DONALDY = {
     "id": "7050",
@@ -93,8 +93,8 @@ class SubscriptionsCase(MachineCase):
         # download product info from the candlepin machine
         def download_product(product):
             prod_id = product["id"]
-            filename = os.path.join(self.tmpdir, "%s.pem" % prod_id)
-            self.candlepin.download("/home/admin/candlepin/generated_certs/%s.pem" % prod_id, filename)
+            filename = os.path.join(self.tmpdir, f"{prod_id}.pem")
+            self.candlepin.download(f"/home/admin/candlepin/generated_certs/{prod_id}.pem", filename)
             m.upload([filename], "/etc/pki/product-default")
 
         m.execute(["mkdir", "-p", "/etc/pki/product-default"])


### PR DESCRIPTION
Various changes for the test scripts, with no actual behaviour changes:
- use existing APIs from the cockpit testlib (`testOnly()`, `Machine.write()`)
- use `/etc/pki/product-default` for product certificates
- use a simpler way to wait for Candlepin
- drop the no more needed activation key Python script
- switch usages of `%` string interpolation with f-strings