### PR TITLE
fix: Drop deprecated cockpit.resolve()

### DIFF
--- a/src/insights.jsx
+++ b/src/insights.jsx
@@ -120,7 +120,7 @@ export function unregister() {
         return cockpit.spawn([ "insights-client", "--unregister" ], { superuser: true, err: "out" })
                 .catch(catch_error);
     } else {
-        return cockpit.resolve();
+        return Promise.resolve();
     }
 }
 


### PR DESCRIPTION
cockpit.{resolve,reject} have been deprecated for years. Use the standard JS promise API.