### PR TITLE
Stop using deprecated translatable for html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -19,7 +19,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
 <html lang="en">
 <head>
-    <title translatable="yes">Subscriptions</title>
+    <title translate="yes">Subscriptions</title>
     <meta charset="utf-8">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Since 2019(!) translatable is deprecated up by our `html2po.js` script and replaced by `translate` or `translate="yes"`.