### PR TITLE
Various fixes in state management

### DIFF
--- a/src/insights.jsx
+++ b/src/insights.jsx
@@ -72,7 +72,7 @@ function spawn_error_to_string(err, data) {
     console.debug(">>>> returning undefined");
 }
 
-export function catch_error(err, data) {
+export function catch_error(err, data, addAlert) {
     let msg = spawn_error_to_string(err, data);
     if (msg) {
         // usually the output of insights-client contains more than a single
@@ -87,6 +87,7 @@ export function catch_error(err, data) {
         msg = "Unable to get any error message.";
     }
     subscriptionsClient.setError("error", msg);
+    addAlert(_("Error"), "danger", msg);
 }
 
 function ensure_installed(update_progress) {
@@ -116,10 +117,10 @@ export function register(update_progress) {
     });
 }
 
-export function unregister() {
+export function unregister(addAlert) {
     if (insights_timer.enabled) {
         return cockpit.spawn(["insights-client", "--unregister"], { superuser: true, err: "out" })
-                .catch(catch_error);
+                .catch((err, data) => catch_error(err, data, addAlert));
     } else {
         return Promise.resolve();
     }

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -401,7 +401,11 @@ class TestSubscriptionsPackages(SubscriptionsCase, PackageCase):
         # Connecting to Insights will not have worked because the
         # insights-client binary is not actually there.
 
-        b.wait_visible("body > div:last-child .pf-v6-c-alert:contains('not-found')")
+        b.wait_in_text(".pf-v6-c-alert.pf-m-danger .pf-v6-c-alert__description", "not-found")
+        # Error can be dismissed, after dismissing there is no other error
+        # checks that error was displayed exactly once
+        b.click(".pf-v6-c-alert.pf-m-danger .pf-v6-c-alert__action button")
+        b.wait_not_present(".pf-v6-c-alert.pf-m-danger")
 
         # Try again with the connection dialog.
 


### PR DESCRIPTION
This improves the managing of state between webui and subscriptionsClient. There is a new `addAlert` handler function which manages alerts and fixes bug where an already present alert was rendered on each new render.

Also fixes createRoot() calling and the following error:
```
Warning: You are calling ReactDOMClient.createRoot() on a container that
has already been passed to createRoot() before. Instead,
call root.render() on the existing root instead if you want to update it.
```