### PR TITLE
gitignore: ignore bots directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ __pycache__/
 dist/
 /pkg/
 package-lock.json
-/bots/
+/bots
 /subscription-manager/
 /subscription-manager-cockpit.spec
 /subscription-manager-cockpit.tar.gz


### PR DESCRIPTION
Change bots entry to /bots as /bots/ only matches when the file is a directory. In case of developers using symlink to only have one local checkout for bots it does not match.