### PR TITLE
test: Pin tasks container

### DIFF
--- a/.cockpit-ci/container
+++ b/.cockpit-ci/container
@@ -1,0 +1,1 @@
+ghcr.io/cockpit-project/tasks:2025-11-03

--- a/.github/workflows/tasks-container-update.yml
+++ b/.github/workflows/tasks-container-update.yml
@@ -1,0 +1,34 @@
+name: tasks-container-update
+on:
+  schedule:
+    - cron: '0 2 * * 1'
+  # can be run manually on https://github.com/cockpit-project/subscription-manager-cockpit/actions
+  workflow_dispatch:
+jobs:
+  tasks-container-update:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
+    container:
+      image: ghcr.io/cockpit-project/tasks
+      options: --user root
+    steps:
+      - name: Set up configuration and secrets
+        run: |
+          printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
+          mkdir -p ~/.config
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
+
+      - name: Clone repository
+        uses: actions/checkout@v5
+
+      # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+      - name: Pacify git's permission check
+        run: git config --global --add safe.directory /__w/subscription-manager-cockpit/subscription-manager-cockpit
+
+      - name: Run tasks-container-update
+        run: |
+          make bots
+          bots/tasks-container-update


### PR DESCRIPTION
This moves updating the test container and upgrading it through a PR instead of spontaneously.

----

Yesterday's tasks refresh picked up a broken Chromium, so all sub-man tests fail now and break all image refreshes. E.g. [this one](https://logs-cockpit.apps.ocp.cloud.ci.centos.org/pull-8431-41f30a23-20251108-230051-fedora-42-cockpit-project-subscription-manager-cockpit/log.html).