### PR TITLE
vm.install: add python3-setuptools sub-manager build dependency

### DIFF
--- a/test/vm.install-sub-man
+++ b/test/vm.install-sub-man
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 
-dnf install -y cockpit-ws python3-devel openssl-devel intltool gcc
+dnf install -y cockpit-ws python3-devel python3-setuptools openssl-devel intltool gcc
 
 rm -f /usr/*bin/subscription-manager
 


### PR DESCRIPTION
In vm.install subscription-manager (the "backend") is set up and python3-setuptools is a build dependency. It is pulled into our other images but fedora-43 is missing it.

Realistically we should probably move this to `fedora.setup` but since this is a sub-man build dependency I'll keep it here for now as it is faster way to onboard fedora-43 tests and there are multiple other build dependencies.