### PR TITLE
test: drop redundant wait_visible calls

### DIFF
--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -94,8 +94,6 @@ class TestSubscriptions(SubscriptionsCase):
         # wait until we can open the registration dialog
         b.click(register_button_sel)
 
-        b.wait_visible("#subscription-register-url")
-
         # enter server and incorrect login data
         b.set_val("#subscription-register-url", "custom")
         b.set_input_text("#subscription-register-url-custom", CANDLEPIN_URL)
@@ -158,7 +156,6 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(register_button_sel)
 
         # enter server data
-        b.wait_visible("#subscription-register-url")
         b.set_val("#subscription-register-url", "custom")
         b.set_input_text("#subscription-register-url-custom", CANDLEPIN_URL)
 
@@ -203,7 +200,6 @@ class TestSubscriptions(SubscriptionsCase):
         self.login_and_go("/subscriptions")
 
         b.click("button:contains('Register')")
-        b.wait_visible("#subscription-register-url")
 
         b.set_val("#subscription-register-url", "custom")
         b.set_input_text("#subscription-register-url-custom", CANDLEPIN_URL)
@@ -285,7 +281,6 @@ class TestSubscriptions(SubscriptionsCase):
         self.login_and_go("/subscriptions")
 
         b.click("button:contains('Register')")
-        b.wait_visible("#subscription-register-url")
 
         b.set_val("#subscription-register-url", "custom")
         b.set_input_text("#subscription-register-url-custom", CANDLEPIN_URL)
@@ -395,7 +390,6 @@ class TestSubscriptionsPackages(SubscriptionsCase, packagelib.PackageCase):
         self.login_and_go("/subscriptions")
 
         b.click("button:contains('Register')")
-        b.wait_visible("#subscription-register-url")
 
         b.set_val("#subscription-register-url", "custom")
         b.set_input_text("#subscription-register-url-custom", CANDLEPIN_URL)


### PR DESCRIPTION
The `set_val` implementation already calls wait_visible so the check in the test is redundant.