### PR TITLE
test: set machine memory_mb via provision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,10 +229,8 @@ prepare-check: $(NODE_MODULES_TEST) $(VM_IMAGE) test/common test/reference
 
 # run the browser integration tests;
 # this will run all tests/check-* and format them as TAP.
-# Because the candlepin container uses a lot of available memory in the nondestructive VM
-# we bump the memory limit to 2048MB
 check: prepare-check
-	test/common/run-tests --nondestructive-memory-mb 2048 ${RUN_TESTS_OPTIONS}
+	test/common/run-tests ${RUN_TESTS_OPTIONS}
 
 # checkout Cockpit's bots for standard test VM images and API to launch them
 # must be from main, as only that has current and existing images; but testvm.py API is stable

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -34,6 +34,12 @@ CANDLEPIN_URL = f"https://{CANDLEPIN_HOSTNAME}:8443/candlepin"
 
 
 class SubscriptionsCase(testlib.MachineCase):
+    # Because the candlepin container uses a lot of available memory
+    # we bump the memory limit to 2048MB
+    provision = {  # noqa: RUF012
+        "0": {"memory_mb": 2048 }
+    }
+
 
     def setUp(self):
         super().setUp()
@@ -78,7 +84,6 @@ authmethod=CERT
             m.execute(["subscription-manager", "unregister"])
 
 
-@testlib.nondestructive
 class TestSubscriptions(SubscriptionsCase):
     def testRegister(self):
         b = self.browser
@@ -373,7 +378,6 @@ class TestSubscriptions(SubscriptionsCase):
         b.wait_visible("#overview button:contains('Register')")
 
 
-@testlib.nondestructive
 class TestSubscriptionsPackages(SubscriptionsCase, packagelib.PackageCase):
     def testMissingPackages(self):
         m = self.machine


### PR DESCRIPTION
`run-tests` doens't allow `--sit` which is super useful for debugging, so prefer setting the memory limits via `provision`.