### PR TITLE
fix: remove race condition causing testUnpriv flake

### DIFF
--- a/src/subscriptions-client.js
+++ b/src/subscriptions-client.js
@@ -508,11 +508,6 @@ client.getSubscriptionStatus = function() {
             .then(() => {
                 getSubscriptionDetails();
                 needRender();
-            })
-            .catch(ex => {
-                console.debug(ex);
-                client.subscriptionStatus.status = "unknown";
-                client.subscriptionStatus.status_msg = _("Unknown");
             });
 
     return promise;


### PR DESCRIPTION
getSubscriptionStatus() had an internal .catch that set status to "unknown" without calling needRender(). Due to promise microtask ordering, this always ran after statusUpdateFailed() (called by requestSubscriptionStatusUpdate) had already correctly set status to "access-denied". The silent overwrite left the UI stuck on the loading spinner for unprivileged users.

The error handling is already properly done by statusUpdateFailed() through the caller chain, so the redundant .catch was simply removed.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>



:warning: This PR was produced almost entirely unattended by Claude as a test of an automatic automatic-flake-fixing bot that I'm working on.  I've not reviewed the code at all.  Do not merge it without careful review and discussion.  I've asked Claude to explain itself and it produced this text: :warning:

# Fix: testUnpriv flaky test — status race condition

## The problem

The test `TestSubscriptions.testUnpriv` was flaking at an 81.8% failure rate
(9/11 attempts) across unrelated PRs on rhel-10-2/devel. The test creates an
unprivileged user "junior", logs into Cockpit, navigates to the Subscriptions
page, and expects to see the message "current user isn't allowed to access
system subscription status." Instead, the page was stuck on "Retrieving
subscription status..." — the loading spinner — until the test timed out.

## What the evidence showed

All 3 collected failure instances were identical:

- **Screenshots**: the page showing a spinner with "Updating" / "Retrieving
  subscription status..."
- **JS console**: repeated `"Peer exited with status 1"` (cockpit bridge
  processes failing because the user can't escalate privileges) followed by
  `"Subscription status update failed: Object(4)"`
- **Log excerpts**: the test times out at line 190 waiting for the error text,
  retries, and sometimes passes on retry

The consistency of the failure mode pointed to a deterministic-ish race rather
than an infrastructure issue.

## Root cause

The bug was in the product code, not the test. In
`src/subscriptions-client.js`, `getSubscriptionStatus()` had two competing
error handlers for the same D-Bus connection failure:

1. **`statusUpdateFailed()`**, called by the outer
   `requestSubscriptionStatusUpdate().catch(...)` — this correctly set
   `status = "access-denied"` and called `needRender()` to trigger a React
   re-render.

2. **An internal `.catch`** on a side promise chain inside
   `getSubscriptionStatus()` — this unconditionally overwrote
   `status = "unknown"` and did **not** call `needRender()`.

Due to JavaScript promise microtask ordering, handler #2 always ran after #1.
The sequence was:

1. `statusUpdateFailed()` sets status to `"access-denied"`, calls
   `needRender()`, which synchronously dispatches a `dataChanged` event, which
   calls `setState()` capturing `"access-denied"`
2. The internal `.catch` then overwrites the client's status to `"unknown"` —
   silently, with no re-render

This alone would make it fail every time, but `client.init()` fires 4
concurrent D-Bus requests (subscription status, consumer org, syspurpose,
syspurpose status), all of which fail for the unprivileged user. Each failure
calls `statusUpdateFailed()` independently. Whether the test passed or failed
depended on whether any of the *other* requests' `statusUpdateFailed()`
happened to fire **after** the internal "unknown" overwrite — restoring
`"access-denied"` and triggering another `needRender()`. Since all requests
race against independent cockpit bridge process failures, this timing was
non-deterministic, producing the ~82% failure rate.

When status was left as `"unknown"`, the view's render method
(`src/subscriptions-view.jsx:587-601`) didn't match it against the error
conditions (`"access-denied"`, `"not-found"`, `"service-unavailable"`), and
since `config.loaded` was also `false` (config D-Bus call also fails for
unprivileged users), it fell through to `renderLoading()` — the permanent
spinner.

## The fix

Removed the 5-line internal `.catch` block from `getSubscriptionStatus()`. It
was redundant — error handling is already properly delegated to
`statusUpdateFailed()` through the `requestSubscriptionStatusUpdate()` caller
chain. The success-path `.then()` (which calls `getSubscriptionDetails()` and
`needRender()`) was preserved since it's still needed when the D-Bus call
succeeds.

```diff
     promise
             .then(() => {
                 getSubscriptionDetails();
                 needRender();
-            })
-            .catch(ex => {
-                console.debug(ex);
-                client.subscriptionStatus.status = "unknown";
-                client.subscriptionStatus.status_msg = _("Unknown");
             });
```
