### PR TITLE
Handle missing subscription client event

### DIFF
--- a/src/subscriptions-view.jsx
+++ b/src/subscriptions-view.jsx
@@ -404,6 +404,7 @@ class SubscriptionsView extends React.Component {
             syspurpose: subscriptionsClient.syspurposeStatus.info,
             syspurpose_status: subscriptionsClient.syspurposeStatus.status,
             insights_available: subscriptionsClient.insightsAvailable,
+            loaded: subscriptionsClient.config.loaded,
             org: subscriptionsClient.org
         });
     }
@@ -588,7 +589,7 @@ class SubscriptionsView extends React.Component {
     render() {
         const status = this.state.status;
         const status_msg = this.state.status_msg;
-        const loaded = subscriptionsClient.config.loaded;
+        const loaded = this.state.loaded;
         if (status === 'not-found' ||
             status === 'access-denied' ||
             status === 'service-unavailable') {

--- a/src/subscriptions-view.jsx
+++ b/src/subscriptions-view.jsx
@@ -410,6 +410,7 @@ class SubscriptionsView extends React.Component {
 
     componentDidMount() {
         subscriptionsClient.addEventListener("dataChanged", this.handleDataChanged);
+        this.handleDataChanged();
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
On page load there is a race condition between subscription client calling `init()` and `componentDidMount` adding an event listener. If `init()` is fast enough the event listener wouldn't catch it, so work around it for now by calling `handleDataChanged` in componentDidMount.

In the future this should be reworked to first register the eventlistener and then call init().