### PR TITLE
Drop "reuse my password for privileged tasks" message

### DIFF
--- a/src/subscriptions-view.jsx
+++ b/src/subscriptions-view.jsx
@@ -514,7 +514,7 @@ class SubscriptionsView extends React.Component {
         let message;
 
         if (status === "service-unavailable") {
-            message = _("The rhsm service is unavailable. Make sure subscription-manager is installed and try reloading the page. Additionally, make sure that you have checked the 'Reuse my password for privileged tasks' checkbox on the login page.");
+            message = _("The rhsm service is unavailable. Make sure subscription-manager is installed and try reloading the page.");
             description = _("Unable to the reach the rhsm service.");
         } else if (status === 'access-denied') {
             message = _("Access denied");


### PR DESCRIPTION
The login page no longer offers this option since Cockpit 219 which is no longer shipped in any supported RHEL release.

Closes: #211