### PR TITLE
test: nondestructive test fixes

### DIFF
--- a/src/subscriptions-view.jsx
+++ b/src/subscriptions-view.jsx
@@ -5,6 +5,7 @@
  */
 
 import cockpit from 'cockpit';
+import { superuser } from 'superuser';
 import React from 'react';
 import subscriptionsClient from './subscriptions-client';
 
@@ -30,6 +31,8 @@ import * as Insights from './insights.jsx';
 import * as Dialog from 'cockpit-components-dialog.jsx';
 
 const _ = cockpit.gettext;
+
+superuser.reload_page_on_change();
 
 class InstalledProducts extends React.Component {
     render() {
@@ -590,7 +593,10 @@ class SubscriptionsView extends React.Component {
         const status = this.state.status;
         const status_msg = this.state.status_msg;
         const loaded = this.state.loaded;
-        if (status === 'not-found' ||
+
+        if (status !== undefined && !superuser.allowed) {
+            return this.renderError("access-denied", "");
+        } else if (status === 'not-found' ||
             status === 'access-denied' ||
             status === 'service-unavailable') {
             return this.renderError(status, status_msg);

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -422,8 +422,7 @@ class TestSubscriptionsPackages(SubscriptionsCase, packagelib.PackageCase):
         # Try again with the connection dialog.
 
         m.execute(["test", "-f", "/stamp-insights-client-999-1"])
-        m.execute([self.packagekit_cmd, "remove", "-y", "insights-client"])
-        m.execute([self.packagekit_cmd, "refresh"])
+        m.execute(["rpm", "--erase", "insights-client"])
 
         b.click("button:contains('Not connected')")
         b.wait_visible('.pf-v6-c-modal-box__body:contains("This system is not connected")')

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -384,7 +384,7 @@ class TestSubscriptionsPackages(SubscriptionsCase, packagelib.PackageCase):
         b = self.browser
 
         if m.image.startswith("rhel-"):
-            m.execute([self.packagekit_cmd, "remove", "-y", "insights-client"])
+            m.execute("if rpm -q insights-client; then rpm --erase insights-client; fi")
 
         self.createPackage("insights-client", "999", "1")
         self.enableRepo(refresh_repo=True)

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -303,6 +303,7 @@ class TestSubscriptions(SubscriptionsCase):
         m.execute(["cp", "/etc/insights-client/machine-id", "/etc/insights-client/machine-id.orig"])
         m.write("/etc/insights-client/machine-id", str(uuid.uuid4()))
         m.execute(["systemctl", "start", "insights-client"])
+        self.addCleanup(lambda: m.execute(["systemctl", "stop", "insights-client"]))
 
         with b.wait_timeout(60):
             b.wait_visible("#overview button.pf-m-link .pf-v6-c-icon .pf-m-warning")

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -380,7 +380,7 @@ class TestSubscriptionsPackages(SubscriptionsCase, packagelib.PackageCase):
         b = self.browser
 
         if m.image.startswith("rhel-"):
-            m.execute(["pkcon", "remove", "-y", "insights-client"])
+            m.execute([self.packagekit_cmd, "remove", "-y", "insights-client"])
 
         self.createPackage("insights-client", "999", "1")
         self.enableRepo(refresh_repo=True)
@@ -415,8 +415,8 @@ class TestSubscriptionsPackages(SubscriptionsCase, packagelib.PackageCase):
         # Try again with the connection dialog.
 
         m.execute(["test", "-f", "/stamp-insights-client-999-1"])
-        m.execute(["pkcon", "remove", "-y", "insights-client"])
-        m.execute(["pkcon", "refresh"])
+        m.execute([self.packagekit_cmd, "remove", "-y", "insights-client"])
+        m.execute([self.packagekit_cmd, "refresh"])
 
         b.click("button:contains('Not connected')")
         b.wait_visible('.pf-v6-c-modal-box__body:contains("This system is not connected")')

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -185,7 +185,10 @@ class TestSubscriptions(SubscriptionsCase):
         b.click(unregister_button_sel)
 
     def testUnpriv(self):
-        self.machine.execute("useradd junior; echo junior:foobar | chpasswd")
+        m = self.machine
+        m.execute("useradd junior; echo junior:foobar | chpasswd")
+        self.addCleanup(lambda: m.execute("userdel -r junior"))
+
         self.login_and_go("/subscriptions", user="junior")
         self.browser.wait_in_text(
             ".pf-v6-c-empty-state__body", "current user isn't allowed to access system subscription"

--- a/test/check-subscriptions
+++ b/test/check-subscriptions
@@ -337,6 +337,9 @@ class TestSubscriptions(SubscriptionsCase):
         b.wait_not_present("#overview button.pf-m-link .pf-v6-c-icon .pf-m-warning")
 
         b.click("button:contains('Unregister')")
+        # HACK: Unregistering calls `insights-client --unregister` but it does not clean up
+        # the machine-id file which is touched in this test, clean it up manually
+        self.addCleanup(lambda: m.execute(["rm", "-f", "/etc/insights-client/machine-id"]))
         with b.wait_timeout(60):
             b.wait_not_in_text("#overview", "Insights")
         m.execute(["test", "-f", "/etc/insights-client/.unregistered"])


### PR DESCRIPTION
This should hopefully unblock fedora-44 image refresh: https://github.com/cockpit-project/bots/pull/8932