### PR TITLE
test: Don't install packages in image-prepare

### DIFF
--- a/test/vm.install-sub-man
+++ b/test/vm.install-sub-man
@@ -1,7 +1,11 @@
 #!/bin/sh
 set -eux
 
-dnf install -y cockpit-ws python3-devel python3-setuptools openssl-devel intltool gcc
+# HACK: temporarily install dependencies on Fedora until the images have them
+# https://github.com/cockpit-project/bots/pull/9297
+if grep -q '^ID=.*fedora' /usr/lib/os-release; then
+    dnf install -y cockpit-ws python3-devel python3-setuptools openssl-devel intltool gcc
+fi
 
 rm -f /usr/*bin/subscription-manager
 


### PR DESCRIPTION
These packages are now included in the RHEL images so that we can build offline in CI which is needed because AWS has no access to the RHEL repos.